### PR TITLE
Fix for null drawable

### DIFF
--- a/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
@@ -114,8 +114,8 @@ public class KenBurnsView extends ImageView {
 
     @Override
     protected void onDraw(Canvas canvas) {
-        if (!mPaused) {
-            Drawable d = getDrawable();
+        Drawable d = getDrawable();
+        if (!mPaused && d != null) {
             updateDrawableBounds();
 
             // No drawable to animate or bounds are yet to be set? We're done for now.


### PR DESCRIPTION
View has been crashing when no drawable has been set.
