### PR TITLE
Modifies aspect ratio comparison to allow for a tolerance.

### DIFF
--- a/library/src/main/java/com/flaviofaria/kenburnsview/MathUtils.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/MathUtils.java
@@ -46,7 +46,9 @@ public final class MathUtils {
         // Reduces precision to avoid problems when comparing aspect ratios.
         float srcRectRatio = MathUtils.truncate(MathUtils.getRectRatio(r1), 2);
         float dstRectRatio = MathUtils.truncate(MathUtils.getRectRatio(r2), 2);
-        return srcRectRatio == dstRectRatio;
+        
+        // Compares aspect ratios that allows for a tolerance range of [0, 0.01] 
+        return (Math.abs(srcRectRatio-dstRectRatio) <= 0.01f);
     }
 
 


### PR DESCRIPTION
Related to https://github.com/flavioarfaria/KenBurnsView/issues/2

This is still a problem for me. I debugged the MathUtils.haveSameAspectRatio method and found out that every time the exception is thrown the aspect ratios differ in 0.01 because of the previous truncation. 

I have modified the comparison operation to allow for a tolerance so it never returns false for aspect ratios that are practically equals.
