### PR TITLE
Don't set mDrawableRect before image loads and dimensions are known

### DIFF
--- a/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
@@ -292,7 +292,7 @@ public class KenBurnsView extends ImageView {
             mDrawableRect = new RectF();
         }
         Drawable d = getDrawable();
-        if (d != null) {
+        if (d != null && d.getIntrinsicHeight() > 0 && d.getIntrinsicWidth() > 0) {
             mDrawableRect.set(0, 0, d.getIntrinsicWidth(), d.getIntrinsicHeight());
         }
     }


### PR DESCRIPTION
In some cases, for example when using Picasso to load the image, this is getting checked before the image is loaded and thus before the drawable dimensions are known. The experience that results is that it starts SUPER zoomed in (since the mDrawableRect is set to 0, 0, -1, -1) and gradually zooms all the way out. By treating drawables with 0 height/width as not being ready, we can avoid that issue and the experience is a more familiar one.