### PR TITLE
Use minimum width scale in KenBurnsView onDraw

### DIFF
--- a/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
@@ -168,7 +168,9 @@ public class KenBurnsView extends ImageView {
                     // Scale to make the current rect match the smallest drawable dimension.
                     float currRectToDrwScale = Math.min(widthScale, heightScale);
                     // Scale to make the current rect match the viewport bounds.
-                    float currRectToVpScale = mViewportRect.width() / currentRect.width();
+                    float vpWidthScale = mViewportRect.width() / currentRect.width();
+                    float vpHeightScale = mViewportRect.height() / currentRect.height();
+                    float currRectToVpScale = Math.min(vpWidthScale, vpHeightScale);
                     // Combines the two scales to fill the viewport with the current rect.
                     float totalScale = currRectToDrwScale * currRectToVpScale;
 


### PR DESCRIPTION
The current code seems to assume that the drawable width will match the viewport width rather than finding the minimum in the same way as the height. This leads to weirdness when it is not true. An example when this is not true is when a center inside approach is used instead rather than a crop approach.

This PR just brings the width check in line with the existing height ratio check.