### PR TITLE
Enable Center Inside + example transition generator

### DIFF
--- a/library/src/main/java/com/flaviofaria/kenburnsview/FullToRandomTransitionGenerator.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/FullToRandomTransitionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Flavio Faria
+ * Copyright 2015 Flavio Faria and Eric Sieg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,23 @@ import android.view.animation.Interpolator;
 
 import java.util.Random;
 
-public class RandomTransitionGenerator implements TransitionGenerator {
+/**
+ * Transition generator meant to be used in a {@link KenBurnsView} and most likely in a slideshow.
+ * The generator starts full zoomed out and then does a ken burns animation moving in towards a
+ * random part of the image. This does not crop the image and thus works well with an image view
+ * that is using a 'center inside' approach instead of a 'center crop' approach.
+ * @author Eric Sieg
+ * @author Flavio Faria
+ * @see KenBurnsView
+ * @see TransitionGenerator
+ */
+public class FullToRandomTransitionGenerator implements TransitionGenerator {
 
     /** Default value for the transition duration in milliseconds. */
     public static final int DEFAULT_TRANSITION_DURATION = 10000;
 
     /** Minimum rect dimension factor, according to the maximum one. */
-    private static final float MIN_RECT_FACTOR = 0.75f;
+    private static final float MIN_RECT_FACTOR = 0.85f;
 
     /** Random object used to generate arbitrary rects. */
     private final Random mRandom = new Random(System.currentTimeMillis());
@@ -45,44 +55,24 @@ public class RandomTransitionGenerator implements TransitionGenerator {
     private RectF mLastDrawableBounds;
 
 
-    public RandomTransitionGenerator() {
+    public FullToRandomTransitionGenerator() {
         this(DEFAULT_TRANSITION_DURATION, new AccelerateDecelerateInterpolator());
     }
 
 
-    public RandomTransitionGenerator(long transitionDuration, Interpolator transitionInterpolator) {
+    public FullToRandomTransitionGenerator(long transitionDuration, Interpolator transitionInterpolator) {
         setTransitionDuration(transitionDuration);
         setTransitionInterpolator(transitionInterpolator);
     }
 
     public boolean isCroppingImage() {
-        return true;
+        return false;
     }
 
     @Override
     public Transition generateNextTransition(RectF drawableBounds, RectF viewport) {
-        boolean firstTransition = mLastGenTrans == null;
-        boolean drawableBoundsChanged = true;
-        boolean viewportRatioChanged = true;
-
-        RectF srcRect = null;
-        RectF dstRect = null;
-
-        if (!firstTransition) {
-            dstRect = mLastGenTrans.getDestinyRect();
-            drawableBoundsChanged = !drawableBounds.equals(mLastDrawableBounds);
-            viewportRatioChanged = !MathUtils.haveSameAspectRatio(dstRect, viewport);
-        }
-
-        if (dstRect == null || drawableBoundsChanged || viewportRatioChanged) {
-            srcRect = generateRandomRect(drawableBounds, viewport);
-        } else {
-            /* Sets the destiny rect of the last transition as the source one
-             if the current drawable has the same dimensions as the one of
-             the last transition. */
-            srcRect = dstRect;
-        }
-        dstRect = generateRandomRect(drawableBounds, viewport);
+        RectF srcRect = generateFullBalancedRect(drawableBounds, viewport);
+        RectF dstRect = generateRandomRect(drawableBounds, viewport);
 
         mLastGenTrans = new Transition(srcRect, dstRect, mTransitionDuration,
                 mTransitionInterpolator);
@@ -94,40 +84,43 @@ public class RandomTransitionGenerator implements TransitionGenerator {
 
 
     /**
-     * Generates a random rect that can be fully contained within {@code drawableBounds} and
-     * has the same aspect ratio of {@code viewportRect}. The dimensions of this random rect
-     * won't be higher than the largest rect with the same aspect ratio of {@code viewportRect}
-     * that {@code drawableBounds} can contain. They also won't be lower than the dimensions
-     * of this upper rect limit weighted by {@code MIN_RECT_FACTOR}.
+     * Generates a random rect that can be fully contained within {@code drawableBounds}.
+     * The dimensions of this random rect won't be higher than the largest rect with the same
+     * aspect ratio of {@code viewportRect} that {@code drawableBounds} can contain.
+     * They also won't be lower than the dimensions of this upper rect limit weighted
+     * by {@code MIN_RECT_FACTOR}.
      * @param drawableBounds the bounds of the drawable that will be zoomed and panned.
-     * @param viewportRect the bounds of the view that the drawable will be shown.
-     * @return an arbitrary generated rect with the same aspect ratio of {@code viewportRect}
-     * that will be contained within {@code drawableBounds}.
+     * @param viewportRect the bounds of the view that the drawable will be shown inside.
+     * @return an arbitrary generated rect that will be contained within {@code drawableBounds}.
      */
     private RectF generateRandomRect(RectF drawableBounds, RectF viewportRect) {
-        float drawableRatio = MathUtils.getRectRatio(drawableBounds);
-        float viewportRectRatio = MathUtils.getRectRatio(viewportRect);
-        RectF maxCrop;
 
-        if (drawableRatio > viewportRectRatio) {
-            float r = (drawableBounds.height() / viewportRect.height()) * viewportRect.width();
-            float b = drawableBounds.height();
-            maxCrop = new RectF(0, 0, r, b);
-        } else {
-            float r = drawableBounds.width();
-            float b = (drawableBounds.width() / viewportRect.width()) * viewportRect.height();
-            maxCrop = new RectF(0, 0, r, b);
-        }
+        float widthRatio =  viewportRect.width() / drawableBounds.width();
+        float heightRatio = viewportRect.height() / drawableBounds.height();
+        float smallestRatio = widthRatio > heightRatio ? heightRatio : widthRatio;
 
         float randomFloat = MathUtils.truncate(mRandom.nextFloat(), 2);
         float factor = MIN_RECT_FACTOR + ((1 - MIN_RECT_FACTOR) * randomFloat);
 
-        float width = factor * maxCrop.width();
-        float height = factor * maxCrop.height();
+        float width = drawableBounds.width() * smallestRatio * factor;
+        float height = drawableBounds.height() * smallestRatio * factor;
         int widthDiff = (int) (drawableBounds.width() - width);
         int heightDiff = (int) (drawableBounds.height() - height);
         int left = widthDiff > 0 ? mRandom.nextInt(widthDiff) : 0;
         int top = heightDiff > 0 ? mRandom.nextInt(heightDiff) : 0;
+        return new RectF(left, top, left + width, top + height);
+    }
+
+    private RectF generateFullBalancedRect(RectF drawableBounds, RectF viewportRect) {
+
+        float widthRatio =  viewportRect.width() / drawableBounds.width();
+        float heightRatio = viewportRect.height() / drawableBounds.height();
+        float smallestRatio = widthRatio > heightRatio ? heightRatio : widthRatio;
+
+        float width = drawableBounds.width() * smallestRatio;
+        float height = drawableBounds.height() * smallestRatio;
+        int left = 0;
+        int top = 0;
         return new RectF(left, top, left + width, top + height);
     }
 

--- a/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
@@ -72,7 +72,6 @@ public class KenBurnsView extends ImageView {
      * or after the super class constructor returns. */
     private boolean mInitialized;
 
-
     public KenBurnsView(Context context) {
         this(context, null);
     }
@@ -116,28 +115,36 @@ public class KenBurnsView extends ImageView {
     @Override
     public void setImageBitmap(Bitmap bm) {
         super.setImageBitmap(bm);
-        handleImageChange();
+        if (bm != null) {
+            handleImageChange();
+        }
     }
 
 
     @Override
     public void setImageResource(int resId) {
         super.setImageResource(resId);
-        handleImageChange();
+        if (resId != 0) {
+            handleImageChange();
+        }
     }
 
 
     @Override
     public void setImageURI(Uri uri) {
         super.setImageURI(uri);
-        handleImageChange();
+        if (uri != null) {
+            handleImageChange();
+        }
     }
 
 
     @Override
     public void setImageDrawable(Drawable drawable) {
         super.setImageDrawable(drawable);
-        handleImageChange();
+        if (drawable != null && drawable.getIntrinsicHeight() > 0 && drawable.getIntrinsicWidth() > 0) {
+            handleImageChange();
+        }
     }
 
 
@@ -181,6 +188,13 @@ public class KenBurnsView extends ImageView {
                        of the current rect into the entire view. */
                     mMatrix.reset();
                     mMatrix.postTranslate(-mDrawableRect.width() / 2, -mDrawableRect.height() / 2);
+                    /* Center the drawable Rect if it is not already cropped to match the
+                        viewport dimensions. Only apply if image is uncropped.
+                     */
+                    if (!mTransGen.isCroppingImage()) {
+                        mMatrix.postTranslate((mViewportRect.width() - mDrawableRect.width()) / 2,
+                                (mViewportRect.height() - mDrawableRect.height()) / 2);
+                    }
                     mMatrix.postScale(totalScale, totalScale);
                     mMatrix.postTranslate(translX, translY);
 
@@ -239,7 +253,7 @@ public class KenBurnsView extends ImageView {
      * @return
      */
     private boolean hasBounds() {
-        return !mViewportRect.isEmpty();
+        return mDrawableRect.right > 0 && mDrawableRect.bottom > 0 && !mViewportRect.isEmpty();
     }
 
 

--- a/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/KenBurnsView.java
@@ -168,7 +168,9 @@ public class KenBurnsView extends ImageView {
                     // Scale to make the current rect match the smallest drawable dimension.
                     float currRectToDrwScale = Math.min(widthScale, heightScale);
                     // Scale to make the current rect match the viewport bounds.
-                    float currRectToVpScale = mViewportRect.width() / currentRect.width();
+                    float vpWidthScale = mViewportRect.width() / currentRect.width();
+                    float vpHeightScale = mViewportRect.height() / currentRect.height();
+                    float currRectToVpScale = Math.min(vpWidthScale, vpHeightScale);
                     // Combines the two scales to fill the viewport with the current rect.
                     float totalScale = currRectToDrwScale * currRectToVpScale;
 

--- a/library/src/main/java/com/flaviofaria/kenburnsview/TransitionGenerator.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/TransitionGenerator.java
@@ -29,4 +29,10 @@ public interface TransitionGenerator {
      */
     public Transition generateNextTransition(RectF drawableBounds, RectF viewport);
 
+    /**
+     * Identifies whether or not the transition generator is cropping the image. If not, the
+     * resulting image should be centered inside the {@link KenBurnsView}.
+     * @return a {@link boolean} object that identifies whether or not the image is cropped
+     */
+    public boolean isCroppingImage();
 }


### PR DESCRIPTION
For the current app I'm working on, by far the main request was that we stop cropping when doing the Ken Burns because it could look really bad when the picture was a portrait and it was being displayed on a landscaped tablet or phone. Instead they wanted it to start from a fully zoomed out center inside image that would then slowly zoom/pan.  
  
I got that working locally, and wanted to offer this code back to show how it works and some of the changes I had to made to the KenBurnsView along the way to enable the change. I also included an example transition generator. It may not be plug and play for others unless they are doing a slideshow that transitions every X seconds like we were, but if that's the case they can probably pull from the existing RandomTransitionGenerator and this new one to create a generator that meets their needs.  
  
There might be a better way to implement the centering to make it work other than the postTranslate approach I used, but it seemed to work so I didn't look too much beyond that.  
  
One warning with this PR is that it does add a new requirement to the TransitionGenerator interface and so other people that have created their own generators will need to implement the method. For that reason, I created 2 PRs (this one and a much simpler one) in case you would prefer not to pull this one in.  