### PR TITLE
fixed a bug causing drawable bounds being invalid after changing the image

### DIFF
--- a/library/src/main/java/com/flaviofaria/kenburnsview/RandomTransitionGenerator.java
+++ b/library/src/main/java/com/flaviofaria/kenburnsview/RandomTransitionGenerator.java
@@ -84,7 +84,7 @@ public class RandomTransitionGenerator implements TransitionGenerator {
         mLastGenTrans = new Transition(srcRect, dstRect, mTransitionDuration,
                 mTransitionInterpolator);
 
-        mLastDrawableBounds = drawableBounds;
+        mLastDrawableBounds = new RectF(drawableBounds);
 
         return mLastGenTrans;
     }


### PR DESCRIPTION
mLastDrawableBounds needs to be a copy of the bounds not a reference, otherwise this won't work
```java
drawableBoundsChanged = !drawableBounds.equals(mLastDrawableBounds);
```